### PR TITLE
Add web animation performance tier list link to CSS chapter

### DIFF
--- a/content/css.mdx
+++ b/content/css.mdx
@@ -496,6 +496,8 @@ Animations, which animate an object:
 
 Animations rely on ["keyframes"](https://en.wikipedia.org/wiki/Key_frame): a concept borrowed from animation, you specify the properties at specific points, and let the runtime interpolate the middle state (for example, if you know that a box starts at 10px wide and ends at 20px wide, you can infer that half way through that animation, the box should be 15px wide).
 
+Not all animation techniques perform equally well. For a comparison of common approaches, see [Web Animation Performance Tier List](https://motion.dev/magazine/web-animation-performance-tier-list).
+
 ### Pseudo-elements
 
 Selectors can also create elements. For example, `.foo::before` will create an element within all elements with class `foo` but before their children. 

--- a/content/profiling-and-testing.mdx
+++ b/content/profiling-and-testing.mdx
@@ -134,10 +134,6 @@ The solution is to not render all of the rows, a technique known as list virtual
 
 You rarely have to implement list virtualization yourself, consider using [react-virtualized](https://github.com/bvaughn/react-virtualized) and [react-window](https://github.com/bvaughn/react-window).
 
-#### Animation performance
-
-When working with animations, not all approaches are equally performant. For a comparison of the performance characteristics of common web animation techniques, see [Web Animation Performance Tier List](https://motion.dev/magazine/web-animation-performance-tier-list).
-
 ## Testing
 
 As your app gets more complex, you will want to test it.

--- a/content/profiling-and-testing.mdx
+++ b/content/profiling-and-testing.mdx
@@ -134,6 +134,10 @@ The solution is to not render all of the rows, a technique known as list virtual
 
 You rarely have to implement list virtualization yourself, consider using [react-virtualized](https://github.com/bvaughn/react-virtualized) and [react-window](https://github.com/bvaughn/react-window).
 
+#### Animation performance
+
+When working with animations, not all approaches are equally performant. For a comparison of the performance characteristics of common web animation techniques, see [Web Animation Performance Tier List](https://motion.dev/magazine/web-animation-performance-tier-list).
+
 ## Testing
 
 As your app gets more complex, you will want to test it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a link to the [Web Animation Performance Tier List](https://motion.dev/magazine/web-animation-performance-tier-list) article in the Animations subsection of the CSS chapter (`content/css.mdx`), right after the keyframes explanation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eadc4ef2-27a8-4da4-af3c-686bbe5dccd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eadc4ef2-27a8-4da4-af3c-686bbe5dccd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

